### PR TITLE
Only hand off GET and HEAD requests to Fanout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,22 @@ async function handleRequest(event) {
   // Log service version.
   console.log("FASTLY_SERVICE_VERSION: ", env("FASTLY_SERVICE_VERSION") || "local");
 
-  // createFanoutHandoff() creates a Response instance
-  // passing the original request, through Fanout, to the declared backend.
+  if (event.request.method === 'GET' || event.request.method === 'HEAD') {
+    // If it's a GET or HEAD request, then we will pass it through Fanout
 
-  // NOTE: The request handed off to Fanout is the original request 
-  // as it arrived at Compute@Edge. Any modifications made to the request 
-  // before calling createFanoutHandoff() will not be seen by the backend.
-  return createFanoutHandoff(event.request, "origin");
+    // NOTE: In an actual app we would be more selective about which requests
+    // are handed off to Fanout, because requests that are handed off to Fanout
+    // do not pass through the Fastly cache. For example, we may examine the
+    // request path or the existence of certain headers.
+
+    // createFanoutHandoff() creates a Response instance
+    // passing the original request, through Fanout, to the declared backend.
+
+    // NOTE: The request handed off to Fanout is the original request
+    // as it arrived at Compute@Edge. Any modifications made to the request
+    // before calling createFanoutHandoff() will not be seen by the backend.
+    return createFanoutHandoff(event.request, "origin");
+  }
+
+  return fetch(event.request, { backend: "origin" });
 }


### PR DESCRIPTION
It's sufficient to only pass GET and HEAD to Fanout, as HTTP long poll and HTTP streaming only make sense in that context.

Other methods are supposed to work fine anyway, but at the current time Fanout on Fastly gives an error if a POST request with an empty body is made, so this safeguards against that too.