### PR TITLE
Also add handling for WebSocket-over-HTTP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,16 +12,29 @@ async function handleRequest(event) {
   // Log service version.
   console.log("FASTLY_SERVICE_VERSION: ", env("FASTLY_SERVICE_VERSION") || "local");
 
-  if (event.request.method === 'GET' || event.request.method === 'HEAD') {
+  let shouldHandoffToFanout = false;
+  if (
+    event.request.method === 'GET' &&
+    event.request.headers.get('upgrade')?.split(',').some(x => x.trim() === 'websocket')
+  ) {
+    // If a GET request is an "Upgrade: websocket" request, then we also pass it through Fanout
+    // to handle as WebSocket-over-HTTP.
+    // For details on WebSocket-over-HTTP, see https://pushpin.org/docs/protocols/websocket-over-http/
+    shouldHandoffToFanout = true;
+  } else if (event.request.method === 'GET' || event.request.method === 'HEAD') {
     // If it's a GET or HEAD request, then we will pass it through Fanout
+    shouldHandoffToFanout = true;
+  }
 
-    // NOTE: In an actual app we would be more selective about which requests
-    // are handed off to Fanout, because requests that are handed off to Fanout
-    // do not pass through the Fastly cache. For example, we may examine the
-    // request path or the existence of certain headers.
+  // NOTE: In an actual app we would be more selective about which requests
+  // are handed off to Fanout, because requests that are handed off to Fanout
+  // do not pass through the Fastly cache. For example, we may examine the
+  // request path or the existence of certain headers.
 
-    // createFanoutHandoff() creates a Response instance
-    // passing the original request, through Fanout, to the declared backend.
+  if (shouldHandoffToFanout) {
+    // createFanoutHandoff creates a "Response" that, when processed by
+    // event.respondWith(), will perform a passing off the original request,
+    // through Fanout, to the declared backend.
 
     // NOTE: The request handed off to Fanout is the original request
     // as it arrived at Fastly Compute. Any modifications made to the request
@@ -29,5 +42,6 @@ async function handleRequest(event) {
     return createFanoutHandoff(event.request, "origin");
   }
 
+  // Send the request to the declared backend normally.
   return fetch(event.request, { backend: "origin" });
 }


### PR DESCRIPTION
This PR adds handling for the `Upgrade: websocket` header, which would be another condition to hand it off to Fanout to handle as WebSocket-over-HTTP.

Technically this is included in the result for `(method==='GET'||method==='POST')`, but the purpose of this starter kit is to illustrate examples of things to check when passing off through Fanout. A user may want to build logic where only WS-over-HTTP is used, without HTTP streaming. In that case, they can refer to the new logic added here.

