### PR TITLE
Add post-init script to install npm dependencies

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -9,3 +9,4 @@ name = "Fanout forwarding starter kit for JavaScript"
 
 [scripts]
 build = "npm run build"
+post_init = "npm install"


### PR DESCRIPTION
As we do in other JavaScript starter kits such as the default and empty ones
