### PR TITLE
Use Fastly compute action for CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,17 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '18'
-    - uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - run: npm ci
-    - name: build
-      run: npm exec js-compute-runtime ./src/index.js ./bin/main.wasm
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Setup Fastly CLI
+        uses: fastly/compute-actions/setup@v5
+      - name: Install Dependencies
+        run: npm install
+      - name: Build Compute Package
+        uses: fastly/compute-actions/build@v5
+        with:
+          verbose: true


### PR DESCRIPTION
This PR updates the CI build:

* Use `npm install` instead of `npm ci` - this now necessary as a result of #8
* Use Fastly actions to install the CLI and run the build, rather than the previous strategy of directly calling js-compute-runtime.

This is based off of @kpfleming 's work in https://github.com/fastly/compute-starter-kit-typescript/commit/3af2ae5e377000b56a36438f906a45a164382daf
