### PR TITLE
Use @fastly/cli in the starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,24 @@ Learn about Fastly Compute with Fanout using a basic starter that sends connecti
 
 ## Setup
 
+To create an application using this starter kit, create a new directory for your application and switch to it, and then type the following command:
+
+```shell
+npm create @fastly/compute@latest -- --language=javascript --starter-kit=fanout-forward
+```
+
 The app expects a configured backend named "origin" that points to an origin server. For example, if the server is available at domain `example.com`, then you'll need to create a backend on your Fastly Compute service named "origin" with the destination host set to `example.com` and port `443`. Also set `Override Host` to the same host value.
 
+> [!NOTE]
+> Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server) does not support Fanout features. To experiment with Fanout, you will need to publish this project to your Fastly Compute service.
+
+To build and deploy your application to your Fastly account, type the following command. The first time you deploy the application, you will be prompted to create a new service in your account.
+
+```shell
+npm run deploy
+```
+
 After deploying the app and setting up the backend configuration, all connections received by the service will be passed through the Fanout proxy to the origin. If WebSocket-over-HTTP mode is enabled on your service, then client WebSocket activity will be converted into HTTP when sending to the origin.
-
-## Note
-
-This app is not currently supported in Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server), as the development server does not support Fanout features. To experiment with Fanout, you will need to publish this project to your Fastly Compute service. using the `fastly compute publish` command.
 
 ## Security issues
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "@fastly/js-compute": "^3.0.0"
   },
+  "devDependencies": {
+    "@fastly/cli": "^10.14.0"
+  },
   "scripts": {
     "build": "js-compute-runtime ./src/index.js ./bin/main.wasm",
     "deploy": "fastly compute publish"


### PR DESCRIPTION
This PR makes changes:

* Changes to **package.json** to enable usage without a global installation of the Fastly CLI:
   * Adds `@fastly/cli` to `devDependencies` so that it's available when using the starter kit, as a tool used to build and run or publish the application.
   * Makes sure that `scripts` contains `start` and `deploy` scripts as applicable.

* Adds instructions to the README describing how to initialize an application using the starter kit, as well as how to run it locally or publish it to a Fastly service, as applicable.

* Adds `post_init` script to run `npm install` if it was not present.