### PR TITLE
Update starter kit for Fanout endpoints at the edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
-# Fanout forward starter kit for JavaScript
+# Fanout Starter kit for JavaScript
 
 [![Deploy to Fastly](https://deploy.edgecompute.app/button)](https://deploy.edgecompute.app/deploy)
 
-Learn about Fastly Compute with Fanout using a basic starter that sends connections through the Fanout GRIP proxy to a backend.
+Install this starter kit to use Fanout. It routes incoming requests through the Fanout GRIP proxy and on to an origin. It also provides some endpoints for testing subscriptions without an origin.
 
-**For more details about this and other starter kits for Fastly Compute, see the [Fastly Documentation Hub](https://www.fastly.com/documentation/solutions/starters/)**.
+There is no need to modify this kit. It is production-ready for typical Fanout usage that coordinates with an origin. However, if you would like to implement Fanout logic at the edge, this kit is also a good starting point for that, and you can modify it to fit your needs. See the test endpoints for inspiration.
+
+**For more details about this and other starter kits for Compute, see the [Fastly Documentation Hub](https://www.fastly.com/documentation/solutions/starters/)**.
 
 ## Setup
 
-To create an application using this starter kit, create a new directory for your application and switch to it, and then type the following command:
+The app expects a configured backend named "origin" where Fanout-capable requests should be forwarded to.
 
-```shell
-npm create @fastly/compute@latest -- --language=javascript --starter-kit=fanout-forward
+Additionally, for the test endpoints to work, the app expects a configured backend named "self" that points back to app itself. For example, if the service has a domain `foo.edgecompute.app`, then you'll need to create a backend on the service named "self" with the destination host set to `foo.edgecompute.app` and port 443. Also set "Override Host" to the same host value.
+
+## Test Endpoints
+
+For requests made to domains ending in `.edgecompute.app`, the app will handle requests to the following endpoints without forwarding to the origin:
+
+* `/test/websocket`: bi-directional WebSocket
+* `/test/stream`: HTTP streaming of `text/plain`
+* `/test/sse`: SSE (streaming of `text/event-stream`)
+* `/test/long-poll`: Long-polling
+
+Connecting to any of these endpoints will subscribe the connection to channel "test". The WebSocket endpoint echoes back any messages it receives from the client.
+
+Data can be sent to the connections via the GRIP publish endpoint at `https://api.fastly.com/service/{service-id}/publish/`. For example, here's a curl command to send a WebSocket message:
+
+```sh
+curl \
+  -H "Authorization: Bearer {fastly-api-token}" \
+  -d '{"items":[{"channel":"test","formats":{"ws-message":{"content":"hello"}}}]}' \
+  https://api.fastly.com/service/{service-id}/publish/
 ```
 
-The app expects a configured backend named "origin" that points to an origin server. For example, if the server is available at domain `example.com`, then you'll need to create a backend on your Fastly Compute service named "origin" with the destination host set to `example.com` and port `443`. Also set `Override Host` to the same host value.
+## How it works
 
-> [!NOTE]
-> Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server) does not support Fanout features. To experiment with Fanout, you will need to publish this project to your Fastly Compute service.
+Non-test requests are simply forwarded through the Fanout proxy and on to the origin.
 
-To build and deploy your application to your Fastly account, type the following command. The first time you deploy the application, you will be prompted to create a new service in your account.
+For test requests, the app is actually invoked twice.
 
-```shell
-npm run deploy
-```
+1. Initially, a client request arrives at the app without having been routed through the Fanout proxy yet. The app checks for this via the presence of a `Grip-Sig` header. If that header is not present, the app calls `createFanoutHandoff(request, 'self')` and exits. This tells the subsystem that the connection should be routed through Fanout, and is used for HTTP requests controlled by GRIP.
 
-After deploying the app and setting up the backend configuration, all connections received by the service will be passed through the Fanout proxy to the origin. If WebSocket-over-HTTP mode is enabled on your service, then client WebSocket activity will be converted into HTTP when sending to the origin.
+2. Since `self` refers to the same app, a second request is made to the same app, this time coming through Fanout. The app checks for this, and then handles the request accordingly (in `handleTest()`).
+
+## Note
+
+This app is not currently supported in Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server), as the development server does not support Fanout features. To experiment with Fanout, you will need to publish this project to your Fastly Compute service. using the `fastly compute publish` command.
 
 ## Security issues
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Install this starter kit to use Fanout. It routes incoming requests through the Fanout GRIP proxy and on to an origin. It also provides some endpoints for testing subscriptions without an origin.
 
-There is no need to modify this kit. It is production-ready for typical Fanout usage that coordinates with an origin. However, if you would like to implement Fanout logic at the edge, this kit is also a good starting point for that, and you can modify it to fit your needs. See the test endpoints for inspiration.
+There is no need to modify this starter kit. It is production-ready for typical Fanout usage that coordinates with an origin. However, if you would like to implement Fanout logic at the edge, this starter kit is also a good starting point for that, and you can modify it to fit your needs. See the test endpoints for inspiration.
 
 **For more details about this and other starter kits for Compute, see the [Fastly Documentation Hub](https://www.fastly.com/documentation/solutions/starters/)**.
 

--- a/src/fanoutUtil.js
+++ b/src/fanoutUtil.js
@@ -1,0 +1,44 @@
+/**
+ * Returns a GRIP response to initialize a stream
+ *
+ * When Compute receives a non-WebSocket request (i.e. normal HTTP) and wants
+ * to make it long lived (longpoll or SSE), we call handoff_fanout on it, and
+ * Fanout will then forward that request to the nominated backend.  In this app,
+ * that backend is this same Compute service, where we then need to respond
+ * with some Grip headers to tell Fanout to hold the connection for streaming.
+ * This function constructs such a response.
+ *
+ * @param {string} contentType - Value of Content-Type header to specify
+ * @param {string} gripHold - Value of Grip-Hold to specify on the response
+ * @param {string} gripChannel - Name of Grip channel to subscribe the response
+ */
+export function gripResponse(contentType, gripHold, gripChannel) {
+  return new Response(
+    null, {
+      headers: {
+        'Content-Type': contentType,
+        "Grip-Hold": gripHold,
+        "Grip-Channel": gripChannel,
+      },
+    });
+}
+
+const _textEncoder = new TextEncoder();
+
+/**
+ * Returns a WebSocket-over-HTTP formatted TEXT message
+ *
+ * @param {string} message - Text message to send
+ */
+export function wsText(message) {
+  return _textEncoder.encode(`TEXT ${_textEncoder.encode(message).length.toString(16)}\r\n${message}\r\n`);
+}
+
+/**
+ * Returns a channel-subscription command in a WebSocket-over-HTTP format
+ *
+ * @param {string} channel - Name of Grip channel to subscribe to
+ */
+export function wsSubscribe(channel) {
+  return wsText('c:' + JSON.stringify({type: 'subscribe', channel}));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,46 +2,134 @@
 
 import { env } from "fastly:env";
 import { createFanoutHandoff } from "fastly:fanout";
+import { gripResponse, wsSubscribe } from "./fanoutUtil.js";
 
 addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 /**
- * @param { FetchEvent } event
+ * @param {FetchEvent} event
  */
 async function handleRequest(event) {
   // Log service version.
-  console.log("FASTLY_SERVICE_VERSION: ", env("FASTLY_SERVICE_VERSION") || "local");
+  console.log('FASTLY_SERVICE_VERSION: ', env('FASTLY_SERVICE_VERSION') || 'local');
 
-  let shouldHandoffToFanout = false;
+  const request = event.request;
+  const path = new URL(request.url).pathname;
+
+  const host = request.headers.get('host');
+  if (host == null) {
+    return new Response(
+      'Unknown host\n',
+      {
+        status: 404,
+      },
+    );
+  }
+
+  const address = event.client.address;
+  if (address != null) {
+    request.headers.set('X-Forwarded-For', address);
+  }
+
+  if (isTls(request)) {
+    request.headers.set('X-Forwarded-Proto', 'https');
+  }
+
+  // Request is a test request - from client, or from Fanout
+  if (host.endsWith('.edgecompute.app') && path.startsWith('/test/')) {
+
+    if (request.headers.has('Grip-Sig')) {
+      // Request is from Fanout, handle it here
+      return await handleTest(request, 'test');
+    }
+
+    // Not from Fanout, route it through Fanout first
+    return createFanoutHandoff(request, 'self');
+  }
+
+  // Forward all non-test requests to the origin through Fanout
+  return createFanoutHandoff(request, 'origin');
+}
+
+/**
+ * @param {Request} request
+ */
+function isTls(request) {
+  return new URL(request.url).protocol === 'https';
+}
+
+/**
+ * @param {Request} request
+ * @param {string} channel
+ */
+async function handleTest(request, channel) {
+  const path = new URL(request.url).pathname;
+
+  switch(path) {
+    case '/test/long-poll':
+      return gripResponse('text/plain', 'response', channel);
+    case '/test/stream':
+      return gripResponse('text/plain', 'stream', channel);
+    case '/test/sse':
+      return gripResponse('text/event-stream', 'stream', channel);
+    case '/test/websocket':
+      return await handleFanoutWebSocket(request, channel);
+    default:
+      return new Response('No such test endpoint\n', { status: 404 });
+  }
+}
+
+/**
+ * @param {Request} request
+ * @param {string} channel
+ */
+async function handleFanoutWebSocket(request, channel) {
+  if (request.headers.get('Content-Type') !== 'application/websocket-events') {
+    return new Response('Not a WebSocket-over-HTTP request.\n', { status: 400 });
+  }
+
+  // Stream in the request body
+  const reqBody = new Uint8Array(await request.arrayBuffer());
+
+  // Components to build the response
+  const respBodySegments = [
+    reqBody, // echo the request body into the response
+  ];
+  /** @var {Record<string, string>} */
+  const respHeaders = {
+    'Content-Type': 'application/websocket-events',
+  };
+
+  // Is it an open message?
+  const OPEN_MESSAGE_BYTES = new TextEncoder().encode('OPEN\r\n');
   if (
-    event.request.method === 'GET' &&
-    event.request.headers.get('upgrade')?.split(',').some(x => x.trim() === 'websocket')
+    reqBody.length >= OPEN_MESSAGE_BYTES.length &&
+    reqBody.slice(0, OPEN_MESSAGE_BYTES.length).every((b, i) => b === OPEN_MESSAGE_BYTES.at(i))
   ) {
-    // If a GET request is an "Upgrade: websocket" request, then we also pass it through Fanout
-    // to handle as WebSocket-over-HTTP.
-    // For details on WebSocket-over-HTTP, see https://pushpin.org/docs/protocols/websocket-over-http/
-    shouldHandoffToFanout = true;
-  } else if (event.request.method === 'GET' || event.request.method === 'HEAD') {
-    // If it's a GET or HEAD request, then we will pass it through Fanout
-    shouldHandoffToFanout = true;
+    // Subscribe it to the channel
+    respBodySegments.push(wsSubscribe(channel));
+
+    // Sec-WebSocket-Extension 'grip' - https://pushpin.org/docs/protocols/grip/#websocket
+    // "In order to enable GRIP functionality, the backend must include the grip extension in its response."
+    respHeaders['Sec-WebSocket-Extensions'] = 'grip; message-prefix=""';
   }
 
-  // NOTE: In an actual app we would be more selective about which requests
-  // are handed off to Fanout, because requests that are handed off to Fanout
-  // do not pass through the Fastly cache. For example, we may examine the
-  // request path or the existence of certain headers.
+  // Stream out the response body
+  const respBody = new ReadableStream({
+    /** @param {ReadableStreamController<Uint8Array>} controller */
+    start(controller) {
+      for (const segment of respBodySegments) {
+        controller.enqueue(segment);
+      }
+      controller.close();
+    },
+  });
 
-  if (shouldHandoffToFanout) {
-    // createFanoutHandoff creates a "Response" that, when processed by
-    // event.respondWith(), will perform a passing off the original request,
-    // through Fanout, to the declared backend.
-
-    // NOTE: The request handed off to Fanout is the original request
-    // as it arrived at Fastly Compute. Any modifications made to the request
-    // before calling createFanoutHandoff() will not be seen by the backend.
-    return createFanoutHandoff(event.request, "origin");
-  }
-
-  // Send the request to the declared backend normally.
-  return fetch(event.request, { backend: "origin" });
+  return new Response(
+    respBody,
+    {
+      status: 200,
+      headers: respHeaders,
+    },
+  );
 }


### PR DESCRIPTION
This PR updates the Fanout starter kit to include testing endpoints that demonstrate Fanout and that can be used as a starting point for handling Fanout requests at the edge.

It can still be used to forward requests to the origin as before.

The changes are modeled after the Rust starter kit that received similar changes through these pull requests:
https://github.com/fastly/compute-starter-kit-rust-fanout/pull/1
https://github.com/fastly/compute-starter-kit-rust-fanout/pull/19
https://github.com/fastly/compute-starter-kit-rust-fanout/pull/20

It also includes an updated README based on these changes.