### PR TITLE
chore: bump @fastly/cli to v15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@fastly/js-compute": "^3.33.2"
   },
   "devDependencies": {
-    "@fastly/cli": "^14.0.0"
+    "@fastly/cli": "^15.0.0"
   },
   "scripts": {
     "start": "fastly compute serve",


### PR DESCRIPTION
Automated dependency bump across starter kits.